### PR TITLE
[SONARMSBRU-212] Updated profile exporter XML to include plugin data

### DIFF
--- a/SonarQube.TeamBuild.PreProcessor/Roslyn/Model/Deployment.cs
+++ b/SonarQube.TeamBuild.PreProcessor/Roslyn/Model/Deployment.cs
@@ -9,10 +9,19 @@ using System.Xml.Serialization;
 
 namespace SonarQube.TeamBuild.PreProcessor.Roslyn
 {
+
+    /// <summary>
+    /// XML-serializable data class that contains metadata required to deploy analyzers
+    /// </summary>
     public class Deployment
     {
         [XmlArray("NuGetPackages")]
         [XmlArrayItem(Type = typeof(NuGetPackageInfo), ElementName = "NuGetPackage")]
         public List<NuGetPackageInfo> NuGetPackages { get; set; }
+
+        [XmlArray("Plugins")]
+        [XmlArrayItem(Type = typeof(Plugin), ElementName = "Plugin")]
+        public List<Plugin> Plugins { get; set; }
+
     }
 }

--- a/SonarQube.TeamBuild.PreProcessor/Roslyn/Model/Plugin.cs
+++ b/SonarQube.TeamBuild.PreProcessor/Roslyn/Model/Plugin.cs
@@ -1,0 +1,30 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="Plugin.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Xml.Serialization;
+
+namespace SonarQube.TeamBuild.PreProcessor.Roslyn
+{
+    /// <summary>
+    /// XML-serializable data class for a single SonarQube plugin containing an analyzer
+    /// </summary>
+    public class Plugin
+    {
+        [XmlAttribute("Key")]
+        public string Key { get; set; }
+
+        [XmlAttribute("Version")]
+        public string Version { get; set; }
+
+        /// <summary>
+        /// Name of the static resource in the plugin that contains the analyzer artefacts
+        /// </summary>
+        [XmlAttribute("StaticResourceName")]
+        public string StaticResourceName { get; set; }
+
+    }
+}

--- a/SonarQube.TeamBuild.PreProcessor/SonarQube.TeamBuild.PreProcessor.csproj
+++ b/SonarQube.TeamBuild.PreProcessor/SonarQube.TeamBuild.PreProcessor.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Interfaces\ISonarQubeServerFactory.cs" />
     <Compile Include="Interfaces\ITargetsInstaller.cs" />
     <Compile Include="Interfaces\ISonarQubeServer.cs" />
+    <Compile Include="Roslyn\Model\Plugin.cs" />
     <Compile Include="Roslyn\NuGetAnalyzerInstaller.cs" />
     <Compile Include="Roslyn\Model\AdditionalFile.cs" />
     <Compile Include="Roslyn\Model\Configuration.cs" />


### PR DESCRIPTION
The Roslyn profile exporter format has changed to include data about plugins.
This change updates the XML classes to load the new format.