### PR TITLE
TryUpdate should not throw exception about connection timed out

### DIFF
--- a/SonarQube.Bootstrapper/BuildAgentUpdater.cs
+++ b/SonarQube.Bootstrapper/BuildAgentUpdater.cs
@@ -56,8 +56,8 @@ namespace SonarQube.Bootstrapper
                     {
                         return false;
                     }
-
-                    throw;
+                    logger.LogError(Resources.ERROR_FailedToUpdateRunnerBinaries, ex);
+                    return false;
                 }
 
                 logger.LogDebug(Resources.MSG_ExtractingFiles, targetDir);


### PR DESCRIPTION
Try* methods should never throw exceptions. If update fails for unknown reason log the error and continue by notifying that update failed with return false despite the reason. 

I was unable to locate where to create issues to this project, so here is my suggestion as a pull request. 