### PR TITLE
[SONARMSBRU-216] Do not pass non-assemblies to Roslyn

### DIFF
--- a/SonarQube.MSBuild.Tasks/GetAnalyzerSettings.cs
+++ b/SonarQube.MSBuild.Tasks/GetAnalyzerSettings.cs
@@ -8,6 +8,8 @@
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using SonarQube.Common;
+using System;
+using System.Linq;
 
 namespace SonarQube.MSBuild.Tasks
 {
@@ -16,6 +18,9 @@ namespace SonarQube.MSBuild.Tasks
     /// </summary>
     public class GetAnalyzerSettings : Task
     {
+
+        private const string DllExtension = ".dll";
+
         #region Input properties
 
         /// <summary>
@@ -65,7 +70,7 @@ namespace SonarQube.MSBuild.Tasks
 
                     if (settings.AnalyzerAssemblyPaths != null)
                     {
-                        this.AnalyzerFilePaths = settings.AnalyzerAssemblyPaths.ToArray();
+                        this.AnalyzerFilePaths = settings.AnalyzerAssemblyPaths.Where(f => IsAssemblyLibraryFileName(f)).ToArray();
                     }
 
                     if (settings.AdditionalFilePaths != null)
@@ -79,5 +84,19 @@ namespace SonarQube.MSBuild.Tasks
         }
 
         #endregion Overrides
+
+        #region Private methods
+
+        /// <summary>
+        /// Returns whether the supplied string is an assembly library (i.e. dll)
+        /// </summary>
+        private static bool IsAssemblyLibraryFileName(string filePath)
+        {
+            // Not expecting .winmd or .exe files to contain Roslyn analyzers
+            // so we'll ignore them
+            return filePath.EndsWith(DllExtension, StringComparison.OrdinalIgnoreCase);
+        }
+
+        #endregion
     }
 }

--- a/Tests/SonarQube.MSBuild.Tasks.UnitTests/GetAnalyzerSettingsTests.cs
+++ b/Tests/SonarQube.MSBuild.Tasks.UnitTests/GetAnalyzerSettingsTests.cs
@@ -8,6 +8,7 @@
 using Microsoft.Build.Utilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarQube.Common;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using TestUtilities;
@@ -76,13 +77,21 @@ namespace SonarQube.MSBuild.Tasks.UnitTests
             string testDir = TestUtils.CreateTestSpecificFolder(this.TestContext);
             GetAnalyzerSettings testSubject = new GetAnalyzerSettings();
 
-            string[] expectedAnalyzers = new string[] { "c:\\analyzer1.dll", "c:\\analyzer2.dll" };
+            string[] expectedAnalyzers = new string[] { "c:\\analyzer1.DLL", "c:\\analyzer2.dll" };
             string[] expectedAdditionalFiles = new string[] { "c:\\add1.txt", "d:\\add2.txt" };
+
+            // SONARMSBRU-216: non-assembly files should be filtered out
+            List<string> filesInConfig = new List<string>(expectedAnalyzers);
+            filesInConfig.Add("c:\\not_an_assembly.exe");
+            filesInConfig.Add("c:\\not_an_assembly.zip");
+            filesInConfig.Add("c:\\not_an_assembly.txt");
+            filesInConfig.Add("c:\\not_an_assembly.dll.foo");
+            filesInConfig.Add("c:\\not_an_assembly.winmd");
 
             AnalysisConfig config = new AnalysisConfig();
             config.AnalyzerSettings = new AnalyzerSettings();
             config.AnalyzerSettings.RuleSetFilePath = "f:\\yyy.ruleset";
-            config.AnalyzerSettings.AnalyzerAssemblyPaths = expectedAnalyzers.ToList();
+            config.AnalyzerSettings.AnalyzerAssemblyPaths = filesInConfig;
             config.AnalyzerSettings.AdditionalFilePaths = expectedAdditionalFiles.ToList();
             string fullPath = Path.Combine(testDir, FileConstants.ConfigFileName);
             config.Save(fullPath);


### PR DESCRIPTION
Modified the build task to filter out non-assemblies.

[SFSRAP-31] is tracking deciding what files should be embedded in the jar.