### PR TITLE
[SONARMSBRU-245] Prevent invalid build wrapper output property being …

### DIFF
--- a/SonarRunner.Shim/PropertiesFileGenerator.cs
+++ b/SonarRunner.Shim/PropertiesFileGenerator.cs
@@ -20,6 +20,8 @@ namespace SonarRunner.Shim
 
         public const string VSBootstrapperPropertyKey = "sonar.visualstudio.enable";
 
+        public const string BuildWrapperOutputDirectoryKey = "sonar.cfamily.build-wrapper-output";
+
         #region Public methods
 
         /// <summary>
@@ -271,6 +273,9 @@ namespace SonarRunner.Shim
             // There are some properties we want to override regardless of what the user sets
             AddOrSetProperty(VSBootstrapperPropertyKey, "false", properties, logger);
 
+            // Special case processing for known properties
+            RemoveBuildWrapperSettingIfDirectoryEmpty(properties, logger);
+
             return properties;
         }
 
@@ -296,6 +301,39 @@ namespace SonarRunner.Shim
                     property.Value = value;
                 }
             }
+        }
+
+        /// <summary>
+        /// Passing in an invalid value for the build wrapper output directory will cause the C++ plugin to
+        /// fail (invalid = missing or empty directory) so we'll remove invalid settings
+        /// </summary>
+        private static void RemoveBuildWrapperSettingIfDirectoryEmpty(AnalysisProperties properties, ILogger logger)
+        {
+            // The property is set early in the analysis process before any projects are analysed. We can't
+            // tell at this point if the directory missing/empty is error or not - it could just be that all
+            // of the Cpp projects have been excluded from analysis.
+            // We're assuming that if the build wrapper output was not written due to an error elsewhere then
+            // that error will have been logged or reported at the point it occurred. Consequently, we;ll
+            // just write debug output to record what we're doing.
+            Property directoryProperty;
+            if (Property.TryGetProperty(BuildWrapperOutputDirectoryKey, properties, out directoryProperty))
+            {
+                string path = directoryProperty.Value;
+                if (!Directory.Exists(path) || IsDirectoryEmpty(path))
+                {
+                    logger.LogDebug(Resources.MSG_RemovingBuildWrapperAnalysisProperty, BuildWrapperOutputDirectoryKey, path);
+                    properties.Remove(directoryProperty);
+                }
+                else
+                {
+                    logger.LogDebug(Resources.MSG_BuildWrapperPropertyIsValid, BuildWrapperOutputDirectoryKey, path);
+                }
+            }
+        }
+
+        private static bool IsDirectoryEmpty(string path)
+        {
+            return Directory.GetFiles(path, "*.*", SearchOption.AllDirectories).Length == 0;
         }
 
         #endregion

--- a/SonarRunner.Shim/Resources.Designer.cs
+++ b/SonarRunner.Shim/Resources.Designer.cs
@@ -128,6 +128,15 @@ namespace SonarRunner.Shim {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The build wrapper output property {0} has been set and is valid. Specified directory: {1}.
+        /// </summary>
+        public static string MSG_BuildWrapperPropertyIsValid {
+            get {
+                return ResourceManager.GetString("MSG_BuildWrapperPropertyIsValid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Generating SonarQube project properties file to {0}.
         /// </summary>
         public static string MSG_GeneratingProjectProperties {
@@ -169,6 +178,15 @@ namespace SonarRunner.Shim {
         public static string MSG_PropertiesGenerationFailed {
             get {
                 return ResourceManager.GetString("MSG_PropertiesGenerationFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The directory specified in property {0} either does not exist or is empty. The property will be removed. Specified directory: {1}.
+        /// </summary>
+        public static string MSG_RemovingBuildWrapperAnalysisProperty {
+            get {
+                return ResourceManager.GetString("MSG_RemovingBuildWrapperAnalysisProperty", resourceCulture);
             }
         }
         

--- a/SonarRunner.Shim/Resources.resx
+++ b/SonarRunner.Shim/Resources.resx
@@ -232,4 +232,10 @@ Possible causes:
   <data name="MSG_SarifFileIsValid" xml:space="preserve">
     <value>The supplied Code Analysis ErrorLog file is a valid json file and does not need to be fixed: {0}</value>
   </data>
+  <data name="MSG_BuildWrapperPropertyIsValid" xml:space="preserve">
+    <value>The build wrapper output property {0} has been set and is valid. Specified directory: {1}</value>
+  </data>
+  <data name="MSG_RemovingBuildWrapperAnalysisProperty" xml:space="preserve">
+    <value>The directory specified in property {0} either does not exist or is empty. The property will be removed. Specified directory: {1}</value>
+  </data>
 </root>

--- a/Tests/SonarRunner.Shim.Tests/PropertiesFileGeneratorTests.cs
+++ b/Tests/SonarRunner.Shim.Tests/PropertiesFileGeneratorTests.cs
@@ -432,6 +432,75 @@ namespace SonarRunner.Shim.Tests
             logger.AssertWarningsLogged(0); // not expecting a warning if the user has supplied the value we want
         }
 
+        [TestMethod]
+        public void FileGen_BuildWrapperOutputDirIsMissing_PropertyNotWritten()
+        {
+            // Arrange
+            TestLogger logger = new TestLogger();
+            Property buildWrapperProperty = new Property() { Id = PropertiesFileGenerator.BuildWrapperOutputDirectoryKey, Value = "non-existent directory" };
+
+            // Act
+            ProjectInfoAnalysisResult result = ExecuteAndCheckSucceeds("buildwrapper_missingdir", logger, buildWrapperProperty);
+
+            // Assert
+            SQPropertiesFileReader provider = new SQPropertiesFileReader(result.FullPropertiesFilePath);
+            provider.AssertSettingDoesNotExist(PropertiesFileGenerator.BuildWrapperOutputDirectoryKey);
+
+            logger.AssertSingleDebugMessageExists(PropertiesFileGenerator.BuildWrapperOutputDirectoryKey, "non-existent directory");
+            logger.AssertWarningsLogged(0);
+            logger.AssertErrorsLogged(0);
+        }
+
+        [TestMethod]
+        public void FileGen_BuildWrapperOutputDirIsEmpty_PropertyNotWritten()
+        {
+            // Arrange
+            // Create empty folder with empty child folder
+            string emptyFolderPath = TestUtils.CreateTestSpecificFolder(this.TestContext, "empty_bw_output");
+            TestUtils.CreateTestSpecificFolder(this.TestContext, "empty_bw_output\\childDir");
+
+            TestLogger logger = new TestLogger();
+            Property buildWrapperProperty = new Property() { Id = PropertiesFileGenerator.BuildWrapperOutputDirectoryKey, Value = emptyFolderPath };
+
+            // Act
+            ProjectInfoAnalysisResult result = ExecuteAndCheckSucceeds("buildwrapper_emptydir", logger, buildWrapperProperty);
+
+            // Assert
+            SQPropertiesFileReader provider = new SQPropertiesFileReader(result.FullPropertiesFilePath);
+            provider.AssertSettingDoesNotExist(PropertiesFileGenerator.BuildWrapperOutputDirectoryKey);
+
+            logger.AssertSingleDebugMessageExists(PropertiesFileGenerator.BuildWrapperOutputDirectoryKey, emptyFolderPath);
+            logger.AssertWarningsLogged(0);
+            logger.AssertErrorsLogged(0);
+        }
+
+        [TestMethod]
+        public void FileGen_BuildWrapperOutputDirContainsFiles_PropertyIsWritten()
+        {
+            // Arrange
+            // Create directory and file in child directory
+            string bwOutputPath = TestUtils.CreateTestSpecificFolder(this.TestContext, "bw_output_withFiles");
+            string childDir = TestUtils.CreateTestSpecificFolder(this.TestContext, "bw_output_withFiles\\childDir");
+            string contentFilePath = Path.Combine(childDir, "dummy.txt");
+            File.WriteAllText(contentFilePath, "dummy bw output");
+
+            TestLogger logger = new TestLogger();
+            Property buildWrapperProperty = new Property() { Id = PropertiesFileGenerator.BuildWrapperOutputDirectoryKey, Value = bwOutputPath };
+
+            // Act
+            ProjectInfoAnalysisResult result = ExecuteAndCheckSucceeds("buildwrapper_dirwithfiles", logger, buildWrapperProperty);
+
+            // Assert
+            SQPropertiesFileReader provider = new SQPropertiesFileReader(result.FullPropertiesFilePath);
+            string expectedPropertyValue = PropertiesWriter.Escape(bwOutputPath); // property is a path so it will be escaped
+            provider.AssertSettingExists(PropertiesFileGenerator.BuildWrapperOutputDirectoryKey, expectedPropertyValue);
+
+            logger.AssertSingleDebugMessageExists(PropertiesFileGenerator.BuildWrapperOutputDirectoryKey, bwOutputPath);
+
+            logger.AssertWarningsLogged(0);
+            logger.AssertErrorsLogged(0);
+        }
+
         #endregion
 
         #region Assertions


### PR DESCRIPTION
…written to the properties file

This commit only stops invalid values from being written to the properties file.
The property isn't actually set anywhere in the product code yet; that will be in the next PR (keeping it separate because I haven't decided the best way to do that yet).