### PR TITLE
[SONARMSBRU-245] Set the build wrapper output property in the config …

### DIFF
--- a/SonarQube.TeamBuild.PreProcessor/AnalysisConfigGenerator.cs
+++ b/SonarQube.TeamBuild.PreProcessor/AnalysisConfigGenerator.cs
@@ -48,7 +48,7 @@ namespace SonarQube.TeamBuild.PreProcessor
             }
             if (programmaticProperties == null)
             {
-                throw new ArgumentNullException(nameof(programmaticProperties));
+                throw new ArgumentNullException("programmaticProperties");
             }
             if (logger == null)
             {

--- a/SonarQube.TeamBuild.PreProcessor/AnalysisConfigGenerator.cs
+++ b/SonarQube.TeamBuild.PreProcessor/AnalysisConfigGenerator.cs
@@ -18,11 +18,16 @@ namespace SonarQube.TeamBuild.PreProcessor
         /// Combines the various configuration options into the AnalysisConfig file
         /// used by the build and post-processor. Saves the file and returns the config instance.
         /// </summary>
-        /// <returns></returns>
+        /// <param name="args">Processed command line arguments supplied the user</param>
+        /// <param name="buildSettings">Build environment settings</param>
+        /// <param name="serverProperties">Analysis properties downloaded from the SonarQube server</param>
+        /// <param name="analyzerSettings">Specifies the Roslyn analyzers to use</param>
+        /// <param name="programmaticProperties">Any additional programmatically set analysis properties. Any user-specified values will take priority</param>
         public static AnalysisConfig GenerateFile(ProcessedArgs args,
             TeamBuildSettings buildSettings,
             IDictionary<string, string> serverProperties,
             AnalyzerSettings analyzerSettings,
+            AnalysisProperties programmaticProperties,
             ILogger logger)
         {
             if (args == null)
@@ -40,6 +45,10 @@ namespace SonarQube.TeamBuild.PreProcessor
             if (analyzerSettings == null)
             {
                 throw new ArgumentNullException("analyzerSettings");
+            }
+            if (programmaticProperties == null)
+            {
+                throw new ArgumentNullException(nameof(programmaticProperties));
             }
             if (logger == null)
             {
@@ -72,9 +81,12 @@ namespace SonarQube.TeamBuild.PreProcessor
                 }
             }
 
-            // Add command line arguments
+            // Add command line arguments and programmatic properties.
+            // Command line arguments take precedence
+            AggregatePropertiesProvider aggProvider = new AggregatePropertiesProvider(args.LocalProperties, new ListPropertiesProvider(programmaticProperties));
+
             config.LocalSettings = new AnalysisProperties();
-            foreach (var property in args.LocalProperties.GetAllProperties())
+            foreach (var property in aggProvider.GetAllProperties())
             {
                 AddSetting(config.LocalSettings, property.Id, property.Value);
             }

--- a/SonarQube.TeamBuild.PreProcessor/Interfaces/IBuildWrapperInstaller.cs
+++ b/SonarQube.TeamBuild.PreProcessor/Interfaces/IBuildWrapperInstaller.cs
@@ -5,6 +5,8 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using SonarQube.Common;
+
 namespace SonarQube.TeamBuild.PreProcessor
 {
     /// <summary>
@@ -17,7 +19,9 @@ namespace SonarQube.TeamBuild.PreProcessor
         /// server. Does nothing if the C++ plugin is not installed.
         /// </summary>
         /// <param name="server">The SonarQube server to use</param>
-        /// <param name="binDirectory">The location into with the embedded zip should be unzipped</param>
-        void InstallBuildWrapper(ISonarQubeServer server, string binDirectory);
+        /// <param name="binDirectory">The location into which the embedded zip should be unzipped</param>
+        /// <param name="outputDirectory">The standard analysis output directory</param>
+        /// <returns>Returns any analysis properties that should be passed to the sonar-runner. Will no return null.</returns>
+        AnalysisProperties InstallBuildWrapper(ISonarQubeServer server, string binDirectory, string outputDirectory);
     }
 }

--- a/SonarQube.TeamBuild.PreProcessor/TeamBuildPreProcessor.cs
+++ b/SonarQube.TeamBuild.PreProcessor/TeamBuildPreProcessor.cs
@@ -91,7 +91,7 @@ namespace SonarQube.TeamBuild.PreProcessor
 
             ISonarQubeServer server = this.factory.CreateSonarQubeServer(args, this.logger);
 
-            InstallBuildWrapper(server, teamBuildSettings.SonarBinDirectory);
+            AnalysisProperties buildWrapperSettings = InstallBuildWrapper(server, teamBuildSettings.SonarBinDirectory, teamBuildSettings.SonarOutputDirectory);
 
             IDictionary<string, string> serverSettings;
             AnalyzerSettings analyzerSettings;
@@ -101,7 +101,7 @@ namespace SonarQube.TeamBuild.PreProcessor
             }
             Debug.Assert(analyzerSettings != null, "Not expecting the analyzer settings to be null");
 
-            AnalysisConfigGenerator.GenerateFile(args, teamBuildSettings, serverSettings, analyzerSettings, this.logger);
+            AnalysisConfigGenerator.GenerateFile(args, teamBuildSettings, serverSettings, analyzerSettings, buildWrapperSettings, this.logger);
 
             return true;
         }
@@ -176,11 +176,11 @@ namespace SonarQube.TeamBuild.PreProcessor
             RulesetGenerator.Generate(server, requiredPluginKey, language, repository, projectKey, projectBranch, path);
         }
 
-        private void InstallBuildWrapper(ISonarQubeServer server, string binDirectory)
+        private AnalysisProperties InstallBuildWrapper(ISonarQubeServer server, string binDirectory, string outputDirectory)
         {
             IBuildWrapperInstaller installer = this.factory.CreateBuildWrapperInstaller(this.logger);
             Debug.Assert(installer != null, "Factory should not return null");
-            installer.InstallBuildWrapper(server, binDirectory);
+            return installer.InstallBuildWrapper(server, binDirectory, outputDirectory);
         }
 
         #endregion Private methods

--- a/Tests/SonarQube.TeamBuild.PreProcessor.Tests/AnalysisConfigGeneratorTests.cs
+++ b/Tests/SonarQube.TeamBuild.PreProcessor.Tests/AnalysisConfigGeneratorTests.cs
@@ -49,7 +49,7 @@ namespace SonarQube.TeamBuild.PreProcessor.Tests
             Directory.CreateDirectory(tbSettings.SonarConfigDirectory); // config directory needs to exist
 
             // Act
-            AnalysisConfig actualConfig = AnalysisConfigGenerator.GenerateFile(args, tbSettings, serverSettings, analyzerSettings, logger);
+            AnalysisConfig actualConfig = AnalysisConfigGenerator.GenerateFile(args, tbSettings, serverSettings, analyzerSettings, new AnalysisProperties(), logger);
 
             // Assert
             AssertConfigFileExists(actualConfig);
@@ -103,7 +103,7 @@ namespace SonarQube.TeamBuild.PreProcessor.Tests
             Directory.CreateDirectory(settings.SonarConfigDirectory); // config directory needs to exist
 
             // Act
-            AnalysisConfig actualConfig = AnalysisConfigGenerator.GenerateFile(args, settings, new Dictionary<string, string>(), new AnalyzerSettings(), logger);
+            AnalysisConfig actualConfig = AnalysisConfigGenerator.GenerateFile(args, settings, new Dictionary<string, string>(), new AnalyzerSettings(), new AnalysisProperties(), logger);
 
             // Assert
             AssertConfigFileExists(actualConfig);
@@ -139,8 +139,7 @@ namespace SonarQube.TeamBuild.PreProcessor.Tests
 
             // Sensitive values - should not be written to the config file
             cmdLineArgs.AddProperty(SonarProperties.DbPassword, "secret db password");
-            cmdLineArgs.AddProperty(SonarProperties.DbUserName, "secret db user");
-
+ 
             // Create a settings file with public and sensitive data
             AnalysisProperties fileSettings = new AnalysisProperties();
             fileSettings.Add(new Property() { Id = "file.public.key", Value = "file public value" });
@@ -161,11 +160,18 @@ namespace SonarQube.TeamBuild.PreProcessor.Tests
             serverProperties.Add("sonar.vbnet.license.secured", "secret license");
             serverProperties.Add("sonar.cpp.License.Secured", "secret license 2");
 
+            // Programmatic properties
+            AnalysisProperties progProperties = new AnalysisProperties();
+            // Non-sensitive
+            progProperties.Add(new Property() { Id = "prog.key.1", Value = "prog value 1" });
+            // Sensitive
+            progProperties.Add(new Property() { Id = SonarProperties.DbUserName, Value = "secret db user" });
+
             TeamBuildSettings settings = TeamBuildSettings.CreateNonTeamBuildSettingsForTesting(analysisDir);
             Directory.CreateDirectory(settings.SonarConfigDirectory); // config directory needs to exist
 
             // Act
-            AnalysisConfig config = AnalysisConfigGenerator.GenerateFile(args, settings, serverProperties, new AnalyzerSettings(), logger);
+            AnalysisConfig config = AnalysisConfigGenerator.GenerateFile(args, settings, serverProperties, new AnalyzerSettings(), progProperties, logger);
 
             // Assert
             AssertConfigFileExists(config);
@@ -183,10 +189,52 @@ namespace SonarQube.TeamBuild.PreProcessor.Tests
             AssertExpectedLocalSetting("sonar.user.license.secured", "user input license", config); // we only filter out *.secured server settings
             AssertExpectedLocalSetting("sonar.value", "value.secured", config);
             AssertExpectedLocalSetting("server.key.secured.xxx", "not really secure", config);
+            AssertExpectedLocalSetting("prog.key.1", "prog value 1", config);
             AssertExpectedServerSetting("server.key.1", "server value 1", config);
 
             AssertFileDoesNotContainText(config.FileName, "file.public.key"); // file settings values should not be in the config
             AssertFileDoesNotContainText(config.FileName, "secret"); // sensitive data should not be in config
+        }
+
+        [TestMethod]
+        public void AnalysisConfGen_CommandLineAndProgrammaticProperties()
+        {
+            // Arrange
+            TestLogger logger = new TestLogger();
+
+            string analysisDir = TestUtils.CreateTestSpecificFolder(this.TestContext);
+            TeamBuildSettings tbSettings = TeamBuildSettings.CreateNonTeamBuildSettingsForTesting(analysisDir);
+
+            Dictionary<string, string> emptyServerProperties = new Dictionary<string, string>();
+            AnalyzerSettings emptyAnalyzerSettings = new AnalyzerSettings();
+            Directory.CreateDirectory(tbSettings.SonarConfigDirectory); // config directory needs to exist
+
+            // Define a set of user properties
+            ListPropertiesProvider userProperties = new ListPropertiesProvider();
+            userProperties.AddProperty("sonar.host.url", "http://host"); // required
+            userProperties.AddProperty("user1", "user value 1");
+            userProperties.AddProperty("shared.key.1", "user value for shared.key.1");
+            ProcessedArgs cmdLineArgs = new ProcessedArgs("key", "name", "version", false, userProperties, EmptyPropertyProvider.Instance);
+            
+            // Define a set of programmatic properties
+            AnalysisProperties programmaticProperties = new AnalysisProperties();
+            programmaticProperties.Add(new Property() { Id = "prog1", Value = "prog value 1" });
+            programmaticProperties.Add(new Property() { Id = "shared.key.1", Value = "prog value for shared.key.1" });
+
+
+            // Act
+            AnalysisConfig actualConfig = AnalysisConfigGenerator.GenerateFile(cmdLineArgs, tbSettings, emptyServerProperties, emptyAnalyzerSettings, programmaticProperties, logger);
+
+            // Assert
+            AssertConfigFileExists(actualConfig);
+            logger.AssertErrorsLogged(0);
+            logger.AssertWarningsLogged(0);
+
+            // Check that user properties take precedence over the programmatic ones
+            AssertExpectedLocalSetting("sonar.host.url", "http://host", actualConfig);
+            AssertExpectedLocalSetting("user1", "user value 1", actualConfig);
+            AssertExpectedLocalSetting("shared.key.1", "user value for shared.key.1", actualConfig);
+            AssertExpectedLocalSetting("prog1", "prog value 1", actualConfig);
         }
 
         #endregion Tests

--- a/Tests/SonarQube.TeamBuild.PreProcessor.Tests/Infrastructure/MockBuildWrapperInstaller.cs
+++ b/Tests/SonarQube.TeamBuild.PreProcessor.Tests/Infrastructure/MockBuildWrapperInstaller.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarQube.Common;
 
 namespace SonarQube.TeamBuild.PreProcessor.Tests
 {
@@ -25,12 +26,15 @@ namespace SonarQube.TeamBuild.PreProcessor.Tests
 
         #region IBuildWrapperInstaller methods
 
-        void IBuildWrapperInstaller.InstallBuildWrapper(ISonarQubeServer server, string binDirectory)
+        AnalysisProperties IBuildWrapperInstaller.InstallBuildWrapper(ISonarQubeServer server, string binDirectory, string outputDirectory)
         {
             Assert.IsNotNull(server, "Supplied server should not be null");
             Assert.IsFalse(string.IsNullOrWhiteSpace(binDirectory), "Supplied bin directory should not be null or empty");
+            Assert.IsFalse(string.IsNullOrWhiteSpace(outputDirectory), "Supplied output directory should not be null or empty");
 
             this.callCount++;
+
+            return new AnalysisProperties();
         }
 
         #endregion


### PR DESCRIPTION
…file

Sets the property in the config file so it can be picked up by the targets.

The property is set by the IBuildWrapperInstaller and passed via the config file to the targets/tasks.
This means that the path is only calculated in one place.