### PR TITLE
SONARMSBRU-239 Increase build-wrapper attach timeout to 60s

### DIFF
--- a/SonarQube.MSBuild.Tasks/AttachBuildWrapper.cs
+++ b/SonarQube.MSBuild.Tasks/AttachBuildWrapper.cs
@@ -41,7 +41,7 @@ namespace SonarQube.MSBuild.Tasks
         /// </summary>
         private readonly int buildWrapperTimeoutInMs;
 
-        private const int DefaultBuildWrapperTimeoutInMs = 5000;
+        private const int DefaultBuildWrapperTimeoutInMs = 60000;
 
         #region Input properties
 

--- a/SonarQube.MSBuild.Tasks/Resources.Designer.cs
+++ b/SonarQube.MSBuild.Tasks/Resources.Designer.cs
@@ -88,7 +88,7 @@ namespace SonarQube.MSBuild.Tasks {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to BuildWrapper: failed to attach to the current process.
+        ///   Looks up a localized string similar to BuildWrapper: failed to attach to the current process. Update the MSBuild Scanner for SonarQube, the C++ and C# plugins to their latest versions and contact the SonarSource support team if this error persists. Note: You can also set the MSBuild property SQEnableBuildWrapper to false to disable the C++ build wrapper integration and get rid of this error..
         /// </summary>
         public static string BuildWrapper_FailedToAttach {
             get {

--- a/SonarQube.MSBuild.Tasks/Resources.resx
+++ b/SonarQube.MSBuild.Tasks/Resources.resx
@@ -200,7 +200,7 @@ Error: {1}</value>
     <value>BuildWrapper: the build wrapper attached successfully</value>
   </data>
   <data name="BuildWrapper_FailedToAttach" xml:space="preserve">
-    <value>BuildWrapper: failed to attach to the current process</value>
+    <value>BuildWrapper: failed to attach to the current process. Update the MSBuild Scanner for SonarQube, the C++ and C# plugins to their latest versions and contact the SonarSource support team if this error persists. Note: You can also set the MSBuild property SQEnableBuildWrapper to false to disable the C++ build wrapper integration and get rid of this error.</value>
   </data>
   <data name="BuildWrapper_RequiredFileMissing" xml:space="preserve">
     <value>BuildWrapper: cannot find required file: {0}</value>


### PR DESCRIPTION
Note: With the current timeout of 5 seconds, the `AttachBW_NotAttached_ExeThrows_TaskFails` test is flaky.

It fails both on my machine and on AppVeyor from time to time: It's expected 0 warnigns to be logged, but in case of a timeout there will be 1.

The warning is logged by `ProcessRunner`:
```
this.outputLogger.LogWarning(Resources.WARN_ExecutionTimedOut, runnerArgs.TimeoutInMilliseconds, runnerArgs.ExeName)
```