### PR TITLE
ProcRunner: Properly escape sonar-runner arguments

### DIFF
--- a/SonarQube.Bootstrapper/Program.cs
+++ b/SonarQube.Bootstrapper/Program.cs
@@ -88,7 +88,7 @@ namespace SonarQube.Bootstrapper
 
             var preprocessorFilePath = settings.PreProcessorFilePath;
 
-            ProcessRunnerArguments runnerArgs = new ProcessRunnerArguments(preprocessorFilePath, logger)
+            ProcessRunnerArguments runnerArgs = new ProcessRunnerArguments(preprocessorFilePath, false, logger)
             {
                 CmdLineArgs = settings.ChildCmdLineArgs,
                 WorkingDirectory = settings.TempDirectory,
@@ -108,7 +108,7 @@ namespace SonarQube.Bootstrapper
                 return ErrorCode;
             }
 
-            ProcessRunnerArguments runnerArgs = new ProcessRunnerArguments(settings.PostProcessorFilePath, logger)
+            ProcessRunnerArguments runnerArgs = new ProcessRunnerArguments(settings.PostProcessorFilePath, false, logger)
             {
                 CmdLineArgs = settings.ChildCmdLineArgs,
                 WorkingDirectory = settings.TempDirectory

--- a/SonarQube.MSBuild.Tasks/AttachBuildWrapper.cs
+++ b/SonarQube.MSBuild.Tasks/AttachBuildWrapper.cs
@@ -173,7 +173,7 @@ namespace SonarQube.MSBuild.Tasks
             string exeName = (Environment.Is64BitOperatingSystem ? BuildWrapperExeName64 : BuildWrapperExeName32);
             string monitorExeFilePath = Path.Combine(this.BinDirectoryPath, exeName);
 
-            ProcessRunnerArguments args = new ProcessRunnerArguments(monitorExeFilePath, new MSBuildLoggerAdapter(this.Log));
+            ProcessRunnerArguments args = new ProcessRunnerArguments(monitorExeFilePath, false, new MSBuildLoggerAdapter(this.Log));
             args.TimeoutInMilliseconds = this.buildWrapperTimeoutInMs;
 
             // See https://jira.sonarsource.com/browse/CPP-1469 for the specification of the arguments to pass to the Cpp plugin

--- a/SonarQube.TeamBuild.Integration/CoverageReportConverter.cs
+++ b/SonarQube.TeamBuild.Integration/CoverageReportConverter.cs
@@ -195,7 +195,7 @@ namespace SonarQube.TeamBuild.Integration
             args.Add(string.Format(System.Globalization.CultureInfo.InvariantCulture, @"/output:""{0}""", outputXmlFilePath));
             args.Add(inputBinaryFilePath);
 
-            ProcessRunnerArguments runnerArgs = new ProcessRunnerArguments(converterExeFilePath, logger)
+            ProcessRunnerArguments runnerArgs = new ProcessRunnerArguments(converterExeFilePath, false, logger)
             {
                 WorkingDirectory = Path.GetDirectoryName(outputXmlFilePath),
                 CmdLineArgs = args,

--- a/SonarRunner.Shim/SonarRunner.Wrapper.cs
+++ b/SonarRunner.Shim/SonarRunner.Wrapper.cs
@@ -142,7 +142,7 @@ namespace SonarRunner.Shim
             Debug.Assert(!String.IsNullOrWhiteSpace(config.SonarRunnerWorkingDirectory), "The working dir should have been set in the analysis config");
             Debug.Assert(Directory.Exists(config.SonarRunnerWorkingDirectory), "The working dir should exist");
 
-            ProcessRunnerArguments runnerArgs = new ProcessRunnerArguments(exeFileName, logger)
+            ProcessRunnerArguments runnerArgs = new ProcessRunnerArguments(exeFileName, true, logger)
             {
                 CmdLineArgs = allCmdLineArgs,
                 WorkingDirectory = config.SonarRunnerWorkingDirectory,

--- a/Tests/SonarQube.TeamBuild.PreProcessor.Tests/V0_9UpgradeMessageTests.cs
+++ b/Tests/SonarQube.TeamBuild.PreProcessor.Tests/V0_9UpgradeMessageTests.cs
@@ -22,7 +22,7 @@ namespace SonarQube.TeamBuild.PreProcessor.Tests
         {
             // Arrange
             TestLogger logger = new TestLogger();
-            ProcessRunnerArguments runnerArgs = new ProcessRunnerArguments(typeof(V0_9UpgradeMessageExe.Program).Assembly.Location, logger)
+            ProcessRunnerArguments runnerArgs = new ProcessRunnerArguments(typeof(V0_9UpgradeMessageExe.Program).Assembly.Location, false, logger)
             {
                 WorkingDirectory = this.TestContext.DeploymentDirectory
             };


### PR DESCRIPTION
@bgavrilMS You'll probably enjoy this PR as well.

The parameters we pass to the sonar-scanner.bat are forwarded to Java using `%*`.
The problem is that batch is a kind of preprocessor, so it starts by rewritten the code to expand all `%variables`, and only then executes what has been rewritten, 1 instruction at a time.

This makes it easy to inject code in the batch script, and it's up to the caller to make sure nothing bad gets injected.

The only impact I could imagine is if a SonarQube's user or password contains special characters such as ` & echo hehe` or perhaps `" & echo hehe`. I didn't test if there was a real end-user problem here, this issue just happened to be spotted while learning about argument passing.